### PR TITLE
Feat: 헤더 컴포넌트, 탭 컴포넌트(헤더 컴포넌트의 하위 컴포넌트) 생성

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
   "extends": ["prettier", "plugin:react/recommended"],
   "plugins": ["react"],
   "rules": {
-    "react/jsx-uses-react": "warn",
+    "react/react-in-jsx-scope": "off",
     "react/jsx-uses-vars": "warn"
   }
 }

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,6 +1,8 @@
-module.exports = function override(config, env) {
+const path = require("path");
+
+module.exports = function override(config) {
   // resolve.extensions 배열에 '.jsx' 추가
-  config.resolve.extensions.push(".jsx")
+  config.resolve.extensions.push(".jsx");
 
   // babel-loader 설정에서 '.jsx' 확장자를 처리할 수 있도록 함
   config.module.rules[1].oneOf.unshift({
@@ -8,9 +10,23 @@ module.exports = function override(config, env) {
     include: config.module.rules[1].oneOf[1].include,
     loader: require.resolve("babel-loader"),
     options: {
-      presets: ["@babel/preset-react"]
+      presets: [
+        [
+          "@babel/preset-react",
+          {
+            runtime: "automatic"
+          }
+        ]
+      ]
     }
-  })
+  });
 
-  return config
-}
+  // 웹팩 alias 설정 추가 (절대 경로)
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    // @: "src" 폴더를 가리키는 별칭
+    ["@"]: path.resolve(__dirname, "src")
+  };
+
+  return config;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "^18.2.0",
         "react-responsive": "^9.0.2",
         "react-router-dom": "^6.17.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "recoil": "^0.7.7",
         "styled-components": "^6.1.0",
         "web-vitals": "^2.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react-router-dom": "^6.17.0",
         "react-scripts": "^5.0.1",
         "recoil": "^0.7.7",
-        "styled-components": "^6.1.0",
+        "styled-components": "^5.3.11",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -2321,10 +2321,15 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
       "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
     "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -4649,11 +4654,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
     },
-    "node_modules/@types/stylis": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.4.tgz",
-      "integrity": "sha512-36ZrGJ8fgtBr6nwNnuJ9jXIj+bn/pF6UoqmrQT7+Y99+tFFeHHsoR54+194dHdyhPjgbeoNz3Qru0oRt0l6ASQ=="
-    },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
@@ -5754,6 +5754,21 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -16784,22 +16799,23 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.1.tgz",
-      "integrity": "sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@emotion/unitless": "^0.8.0",
-        "@types/stylis": "^4.0.2",
-        "css-to-react-native": "^3.2.0",
-        "csstype": "^3.1.2",
-        "postcss": "^8.4.31",
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
-        "stylis": "^4.3.0",
-        "tslib": "^2.5.0"
+        "supports-color": "^5.5.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -16807,7 +16823,8 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
       }
     },
     "node_modules/stylehacks": {
@@ -16824,11 +16841,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/sucrase": {
       "version": "3.34.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "^6.17.0",
     "react-scripts": "^5.0.1",
     "recoil": "^0.7.7",
-    "styled-components": "^6.1.0",
+    "styled-components": "^5.3.11",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0",
     "react-responsive": "^9.0.2",
     "react-router-dom": "^6.17.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "recoil": "^0.7.7",
     "styled-components": "^6.1.0",
     "web-vitals": "^2.1.4"

--- a/src/components/Shared/Header.jsx
+++ b/src/components/Shared/Header.jsx
@@ -1,0 +1,12 @@
+import { FixedHeader, Logo } from "@/styles/CommonStyle";
+import logo from "@/assets/images/logo.png";
+
+const Header = () => {
+  return (
+    <FixedHeader>
+      <Logo src={logo} />
+    </FixedHeader>
+  );
+};
+
+export default Header;

--- a/src/components/Shared/Header.jsx
+++ b/src/components/Shared/Header.jsx
@@ -1,12 +1,42 @@
-import { FixedHeader, Logo } from "@/styles/CommonStyle";
-import logo from "@/assets/images/logo.png";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
-const Header = () => {
+import Tab from "./Tab";
+import { FixedHeader, Logo } from "@/styles/CommonStyle";
+import webLogo from "@/assets/images/logo.png";
+import gameLogo from "@/assets/images/logo-game.png";
+
+const Header = ({ type }) => {
+  let logo;
+
+  if (type === "game") {
+    logo = gameLogo;
+  } else {
+    logo = webLogo;
+  }
+
+  const handleClick = (e) => {
+    if (type === "game") {
+      alert("게임에서 홈으로 넘어갈라 할 때 나오는 경고창");
+    }
+  };
+
   return (
-    <FixedHeader>
-      <Logo src={logo} />
+    <FixedHeader type={type}>
+      <Link to="/" onClick={handleClick}>
+        <Logo src={logo} type={type} />
+      </Link>
+      {(type === "detail" || type === "clearTab") && <Tab type={type}></Tab>}
     </FixedHeader>
   );
+};
+
+Header.propTypes = {
+  type: PropTypes.string
+};
+
+Header.defaultProps = {
+  type: "default"
 };
 
 export default Header;

--- a/src/components/Shared/Tab.jsx
+++ b/src/components/Shared/Tab.jsx
@@ -1,0 +1,42 @@
+import React, { useState, useRef } from "react";
+import PropTypes from "prop-types";
+
+import { SmallWrapper, BottomLink, SpringTab } from "@/styles/CommonStyle";
+
+const Tab = ({ type }) => {
+  const [clickedTab, setClickedTab] = useState(false);
+  const tabsRef = useRef([React.createRef(), React.createRef(), React.createRef()]);
+
+  const handleClick = (e) => {
+    const idx = tabsRef.current.findIndex((tab) => tab.current === e.target);
+    setClickedTab(idx);
+  };
+
+  return (
+    <SmallWrapper align="flex-end" width="23rem" row="between" onClick={handleClick}>
+      <BottomLink to="/notice/list">
+        <SpringTab type={type} ref={tabsRef.current[0]} clicked={clickedTab === 0}>
+          공지
+        </SpringTab>
+      </BottomLink>
+      <BottomLink to="/inquiry/list">
+        <SpringTab type={type} ref={tabsRef.current[1]} clicked={clickedTab === 1}>
+          문의
+        </SpringTab>
+      </BottomLink>
+      <SpringTab type={type} ref={tabsRef.current[2]} clicked={clickedTab === 2}>
+        내 정보
+      </SpringTab>
+    </SmallWrapper>
+  );
+};
+
+Tab.propTypes = {
+  type: PropTypes.string
+};
+
+Tab.defaultProps = {
+  type: "default"
+};
+
+export default Tab;

--- a/src/hooks/useTabClick.js
+++ b/src/hooks/useTabClick.js
@@ -1,3 +1,0 @@
-import { useCallback } from "react";
-
-const useTabClick = () => {};

--- a/src/hooks/useTabClick.js
+++ b/src/hooks/useTabClick.js
@@ -1,0 +1,3 @@
+import { useCallback } from "react";
+
+const useTabClick = () => {};

--- a/src/pages/Web/Home.jsx
+++ b/src/pages/Web/Home.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
 
-import { Gradation, ContentWrapper, WideContent, Header } from "../../styles/CommonStyle";
+import { Gradation, ContentWrapper, WideContent } from "@/styles/CommonStyle";
+import Header from "@/components/Shared/Header";
 
 const Home = () => {
   return (
@@ -17,7 +18,7 @@ const Home = () => {
       {/* 현재 컴포넌트에서만 쓰이는 부분 */}
       <ContentWrapper row="center" col="center">
         <WideContent dir="col">
-          <Header></Header>
+          <Header />
         </WideContent>
       </ContentWrapper>
       {/* 현재 컴포넌트에서만 쓰이는 부분 */}

--- a/src/styles/CommonStyle.jsx
+++ b/src/styles/CommonStyle.jsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import { FlexBox } from "./FlexStyle";
+import { Link } from "react-router-dom";
 
 // 숨겨진 요소
 export const Hidden = styled.div`
@@ -7,23 +8,61 @@ export const Hidden = styled.div`
 `;
 
 // 헤더
-export const FixedHeader = styled(FlexBox).attrs({ as: "header" })`
+export const FixedHeader = styled(FlexBox).attrs(({ type }) => ({
+  as: "header",
+  row: type === "big" ? "center" : "between",
+  col: "center"
+}))`
   position: fixed;
   top: 0;
   width: inherit;
-  height: 7.5rem;
+  height: ${({ type }) => (type === "big" ? "10rem" : "7.5rem")};
   background-color: transparent;
   z-index: 3;
 `;
 
 // 로고 이미지
 export const Logo = styled.img`
-  width: 30px;
-  height: 30px;
+  ${({ type }) => setLogoSize(type)}
 
   &:hover {
     cursor: pointer;
   }
+`;
+
+// 탭 버튼
+export const SpringTab = styled(FlexBox).attrs({ row: "center", col: "center" })`
+  width: 7rem;
+  height: ${(props) => (props.clicked ? "2.5rem" : "3.25rem")};
+  background-color: ${(props) => {
+    if (props.type === "detail") {
+      return props.clicked ? props.theme.colors.content : props.theme.colors.paleBlueGray;
+    } else {
+      return "transparent";
+    }
+  }};
+  border-radius: 15px 15px 0 0;
+  padding-top: 14px;
+  font-family: "Gugi";
+  font-size: 19px;
+  color: #4e4e4e;
+  align-self: flex-end;
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${(props) => {
+      if (props.type === "detail") {
+        return props.clicked ? "#F2F2F2" : "#94a7c1";
+      } else {
+        return "transparent";
+      }
+    }};
+  }
+`;
+
+// 아래로 향하는 링크
+export const BottomLink = styled(Link)`
+  align-self: flex-end;
 `;
 
 // 웹 페이지 그라데이션 영역
@@ -32,7 +71,7 @@ export const Gradation = styled.div`
   top: 0;
   width: 100%;
   height: 42.25rem;
-  background-image: linear-gradient(#dbe1ed, #00000000);
+  background-image: linear-gradient(#dbe1ed, #ffffff00);
   z-index: -1;
 `;
 
@@ -49,6 +88,12 @@ export const WideContent = styled(FlexBox)`
 export const NarrowContent = styled(FlexBox)`
   width: 40.75rem;
   height: 100vh;
+`;
+
+// 작은 요소들을 감싸는 요소
+export const SmallWrapper = styled(FlexBox)`
+  flex-basis: ${(props) => props.width || auto};
+  align-self: ${(props) => props.align || auto};
 `;
 
 // 입력칸의 제목 역할
@@ -78,11 +123,13 @@ export const Input = styled.input.attrs((props) => ({
   `}
 `;
 
+// 메인 갈색 버튼
 export const PrimaryButtonWrapper = styled(FlexBox)`
   width: 100%;
   height: 4.5rem;
 `;
 
+// 메인 갈색 버튼
 export const PrimaryButton = styled.button`
   width: 100%;
   height: inherit;
@@ -96,6 +143,7 @@ export const PrimaryButton = styled.button`
   }
 `;
 
+// 서브 회색 버튼 (모달 등에서 사용)
 export const SecondaryButton = styled.button`
   width: 13.063rem;
   height: 3.625rem;
@@ -110,6 +158,7 @@ export const SecondaryButton = styled.button`
   }
 `;
 
+// 큰 투명 버튼
 export const BigTransparentButton = styled.button`
   width: 9rem;
   height: 4.3rem;
@@ -136,6 +185,7 @@ export const ExitMiniCircle = styled.button`
   }
 `;
 
+// 작은 버튼
 export const SmallButton = styled.button`
   width: 6rem;
   height: 3rem;
@@ -143,6 +193,7 @@ export const SmallButton = styled.button`
   font-weight: 700;
 `;
 
+// 짙은 회색 작은 버튼
 export const SmallDarkButton = styled(SmallButton)`
   background-color: #585858;
   color: #fff;
@@ -152,6 +203,7 @@ export const SmallDarkButton = styled(SmallButton)`
   }
 `;
 
+// 작은 투명 버튼
 export const SmallTransparentButton = styled(SmallButton)`
   background-color: transparent;
   color: #000;
@@ -162,6 +214,7 @@ export const SmallTransparentButton = styled(SmallButton)`
   }
 `;
 
+// 작은 옅은 회색 버튼
 export const SmallGrayButton = styled(SmallButton)`
   background-color: #aaa;
   color: #000;
@@ -171,6 +224,7 @@ export const SmallGrayButton = styled(SmallButton)`
   }
 `;
 
+// 미니 버튼 (관리자 페이지에서 주로 쓰임)
 export const MiniButton = styled.button`
   width: 2.875rem;
   height: 1.688rem;
@@ -179,14 +233,27 @@ export const MiniButton = styled.button`
   font-weight: 700;
 `;
 
+// 파랑 미니 버튼
 export const MiniBlueButton = styled(MiniButton)`
   border: 1px solid ${({ theme }) => theme.colors.success};
   color: ${({ theme }) => theme.colors.success};
 `;
 
+// 빨강 미니 버튼
 export const MiniRedButton = styled(MiniButton)`
   border: 1px solid ${({ theme }) => theme.colors.error};
   color: ${({ theme }) => theme.colors.error};
 `;
 
-// export const FoldButton = styled.button``;
+export const setLogoSize = (type) => {
+  switch (type) {
+    case "big":
+      return `
+        width: 6.75rem;
+      `;
+    default:
+      return `
+        width: 5rem;
+      `;
+  }
+};

--- a/src/styles/CommonStyle.jsx
+++ b/src/styles/CommonStyle.jsx
@@ -7,7 +7,7 @@ export const Hidden = styled.div`
 `;
 
 // 헤더
-export const Header = styled(FlexBox).attrs({ as: "header" })`
+export const FixedHeader = styled(FlexBox).attrs({ as: "header" })`
   position: fixed;
   top: 0;
   width: inherit;
@@ -17,7 +17,14 @@ export const Header = styled(FlexBox).attrs({ as: "header" })`
 `;
 
 // 로고 이미지
-export const Logo = styled.img``;
+export const Logo = styled.img`
+  width: 30px;
+  height: 30px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
 
 // 웹 페이지 그라데이션 영역
 export const Gradation = styled.div`

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,18 +1,29 @@
 import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
+  
+  // 노토 산스
   @font-face {
     font-family: 'Noto Sans KR';
     src: url('/fonts/NotoSansKR-VariableFont_wght.ttf') format('truetype');
     font-weight: 100 900;
   }
 
+  // 프리텐다드
   @font-face {
     font-family: 'Pretendard Variable';
     src: url('/fonts/PretendardVariable.woff2') format('woff2-variations');
     font-weight: 100 900;
   }
 
+  // 구기체
+  @font-face {
+    font-family: 'Gugi';
+    src: url('/fonts/Gugi-Regular.ttf');
+    font-weight: 400;
+  }
+
+  // 던전앤파이터 비트비트체
   @font-face {
     font-family: 'DNFBitBitv2';
     src: url('/fonts/DNFBitBitv2.otf');
@@ -42,6 +53,10 @@ const GlobalStyle = createGlobalStyle`
 
   button {
     border-width: 0;
+  }
+  
+  a {
+    text-decoration: none;
   }
 
   a:hover, button:hover, input[type="submit"] {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -9,6 +9,7 @@ export const sharedTheme = {
     gray700: "#4E4E4D", // 아주 짙은 회색
     error: "#FF6C6C", // 빨강
     success: "#486DFF", // 파랑
+    paleBlueGray: "#B6C6DD", // 채도 낮은 파랑
     kakao: "#FFDE00"
   },
   fontSize: {


### PR DESCRIPTION
**Header 컴포넌트 특징**
헤더의 type에 따라 구성요소가 변경하게 함
※ 헤더의 타입은 총 5가지이며, 구체적인 내용은 다음과 같음 ※
```
 (1) default: 기본 헤더, props에 type을 명시하지 않으면 default  
 (2) game: 게임 페이지 헤더  
 (3) big: 큰 헤더(로그인, 회원가입 페이지 등에서 쓰임)  
 (4) detail: 홈이 아닌 상세 페이지 헤더 (공지, 문의 페이지 등에서 쓰임)  
 (5) clearTab: 탭 부분이 투명색으로 보이는 헤더 (로그인 사용자 홈, 관리자 페이지에서 쓰임)
```

**Tab 컴포넌트 특징**
Header에서 받은 type을 그대로 이어 받아 씀
type이 detail이거나 clearTab인 경우에만 Tab 컴포넌트가 출력되게 함

**절대 경로 설정**
config-overrides.js 안에서 웹팩 별칭(alias) 변경함
src 폴더를 "@"로 가리키게 함
e.g. import Test from "@/components/Shared/Test"

**JSX 파일 내에서 import React 생략 설정**
확장자가 JSX인 파일은 import React from "react"를 쓰지 않고도 JSX 문법이 가능하게 함
(리액트 17버전부터 지원하는 기능, JSX Transform)