### PR TITLE
Feat: InputField 컴포넌트 생성

### DIFF
--- a/src/components/Shared/Form/InputField/InputField.jsx
+++ b/src/components/Shared/Form/InputField/InputField.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Label, Input } from "./InputFieldStyle";
+
+const InputField = ({ type, message }) => {
+  return (
+    <>
+      {/* {Label 포함한 Input (회원가입 등)} */}
+      {type === "label_id" && (
+        <Label>
+          아이디
+          <Input type="text" placeholder="아이디 입력" />
+        </Label>
+      )}
+      {type === "label_pw" && (
+        <Label>
+          비밀번호
+          <Input type="password" placeholder="비밀번호 입력" />
+        </Label>
+      )}
+      {type === "label_pwCheck" && (
+        <Label>
+          비밀번호 확인
+          <Input type="password" placeholder="비밀번호 확인" />
+        </Label>
+      )}
+      {/* {Label 없는 Input} */}
+      {type === "id" && <Input type="text" placeholder="아이디를 입력하세요" />}
+      {type === "pw" && <Input type="password" placeholder={message} />}
+    </>
+  );
+};
+
+InputField.propTypes = {
+  type: PropTypes.string,
+  message: PropTypes.string
+};
+
+export default InputField;

--- a/src/components/Shared/Form/InputField/InputFieldStyle.jsx
+++ b/src/components/Shared/Form/InputField/InputFieldStyle.jsx
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+import { FlexBox } from "@/styles/FlexStyle";
+
+// 입력칸의 제목 역할
+export const Label = styled.label`
+  font-size: ${({ theme }) => theme.fontSize.xxs};
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.gray600};
+`;
+
+// 입력칸
+// type이 text, password, email인 경우에만 스타일 적용
+export const Input = styled.input.attrs((props) => ({
+  type: props.type
+}))`
+  ${({ type, theme }) =>
+    (type === "text" || type === "password" || type === "email") &&
+    `
+    width: 100%;
+    height: 4.3rem;
+    margin-top: 8px;
+    padding: 10px 20px;
+    background-color: #fff;
+    border: 2px solid ${theme.colors.gray100};
+    color: ${theme.colors.text.sub};
+    font-size: ${theme.fontSize.s};
+    font-weight: 500;
+  `}
+`;

--- a/src/components/Shared/Modal/GameModal.jsx
+++ b/src/components/Shared/Modal/GameModal.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const GameModal = () => {};
+
+export default GameModal;

--- a/src/components/Shared/Modal/GameModalStyle.jsx
+++ b/src/components/Shared/Modal/GameModalStyle.jsx
@@ -1,0 +1,2 @@
+import styled from "styled-components";
+import { FlexBox } from "@/styles/FlexStyle";

--- a/src/components/Shared/Modal/ProfileModal.jsx
+++ b/src/components/Shared/Modal/ProfileModal.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ProfileModal = () => {};
+
+export default ProfileModal;

--- a/src/components/Shared/Modal/ProfileModalStyle.jsx
+++ b/src/components/Shared/Modal/ProfileModalStyle.jsx
@@ -1,0 +1,2 @@
+import styled from "styled-components";
+import { FlexBox } from "@/styles/FlexStyle";

--- a/src/styles/CommonStyle.jsx
+++ b/src/styles/CommonStyle.jsx
@@ -36,30 +36,3 @@ export const SmallWrapper = styled(FlexBox)`
   flex-basis: ${(props) => props.width || auto};
   align-self: ${(props) => props.align || auto};
 `;
-
-// 입력칸의 제목 역할
-export const Label = styled.label`
-  font-size: ${({ theme }) => theme.fontSize.xxs};
-  font-weight: 700;
-  color: ${({ theme }) => theme.colors.gray600};
-`;
-
-// 입력칸
-// type이 text, password, email인 경우에만 스타일 적용
-export const Input = styled.input.attrs((props) => ({
-  type: props.type
-}))`
-  ${({ type, theme }) =>
-    (type === "text" || type === "password" || type === "email") &&
-    `
-    width: 100%;
-    height: 4.3rem;
-    margin-top: 8px;
-    padding: 10px 20px;
-    background-color: #fff;
-    border: 2px solid ${theme.colors.gray100};
-    color: ${theme.colors.text.sub};
-    font-size: ${theme.fontSize.s};
-    font-weight: 500;
-  `}
-`;


### PR DESCRIPTION
- 디자인적으로 반복되는 input만 type에 따라 출력될 수 있게 만듦
- 피그마 기준 width : 652px, height: 75px인 input만 만듦
- 나머지는 컨테이너에서 직접 생성
- CommonStyle에서 Label, Input 분리하여 InputFieldStyle에 추가함