### PR TITLE
Fix: PhoneNumberAuth 컴포넌트 수정

### DIFF
--- a/src/components/Web/Shared/Form/PhoneNumberAuth.jsx
+++ b/src/components/Web/Shared/Form/PhoneNumberAuth.jsx
@@ -36,6 +36,7 @@ const PhoneNumberAuth = ({ onVerificationResult }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalMessage, setModalMessage] = useState("");
   const [isVerifying, setIsVerifying] = useState(false); // 전화번호 인증 성공 여부
+  const [isDisabled, setIsDisabled] = useState(false);
 
   // (api 관련)
   const [apiConfig, setApiConfig] = useState(null);
@@ -74,6 +75,9 @@ const PhoneNumberAuth = ({ onVerificationResult }) => {
 
   // 입력칸
   const handleChange = (e) => {
+    setIsDisabled(false);
+    setValidMessage("");
+
     const refIndex = numbersRef.findIndex((ref) => ref.current === e.target);
     // 공백 및 숫자 이외의 문자 제거
     e.target.value = e.target.value.replace(/\s|\D/g, "");
@@ -117,7 +121,7 @@ const PhoneNumberAuth = ({ onVerificationResult }) => {
       }
     });
 
-    e.target.disabled = true;
+    setIsDisabled(true);
   };
 
   /*
@@ -183,7 +187,10 @@ const PhoneNumberAuth = ({ onVerificationResult }) => {
                 </SuccessBox>
               </>
             ) : (
-              <SmallTransparentButton onClick={(e) => sendPhoneNumber(e)}>
+              <SmallTransparentButton
+                disabled={isDisabled}
+                onClick={(e) => sendPhoneNumber(e)}
+              >
                 인증 요청
               </SmallTransparentButton>
             )}
@@ -202,7 +209,7 @@ const PhoneNumberAuth = ({ onVerificationResult }) => {
         </Label>
       </ItemWrapper>
       <>
-        {!isVerifying && isSentPhoneNumber && (
+        {!isVerifying && isSentPhoneNumber && isDisabled && (
           <ItemWrapper marginBottom="20px">
             <Label>
               인증


### PR DESCRIPTION
1. 전화번호를 잘못 입력했을 시, 다시 인증 번호 요청을 할 수 없는 문제 발생
2. 기존에는 인증 버튼을 함수 내에서 직접 disabled 처리했으나 state를 통해 처리하는 방식으로 변경
3. 이에 따라 사용자가 전화번호 입력칸을 수정할 시, 인증 요청이 가능해짐
4. 더불어 인증 번호 입력칸도 disabled 상태값에 따라 출력 여부가 결정됨